### PR TITLE
Raw window handle 0.5

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -23,4 +23,4 @@ nalgebra-glm = "0.10"
 pretty_env_logger = "0.4"
 thiserror = "1"
 vulkanalia = { path = "../vulkanalia", features = ["libloading", "window"] }
-winit = "0.24"
+winit = "0.28.1"

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -78,7 +78,7 @@ impl App {
         let loader = LibloadingLoader::new(LIBRARY)?;
         let entry = Entry::new(loader).map_err(|b| anyhow!("{}", b))?;
         let instance = create_instance(&window, &entry, &mut data)?;
-        data.surface = vk_window::create_surface(&instance, &window)?;
+        data.surface = vk_window::create_surface(&instance, &window, &window)?;
         pick_physical_device(&instance, &mut data)?;
         let device = create_logical_device(&instance, &mut data)?;
         create_swapchain(&window, &instance, &device, &mut data)?;

--- a/vulkanalia/Cargo.toml
+++ b/vulkanalia/Cargo.toml
@@ -26,7 +26,7 @@ window = ["raw-window-handle", "cocoa", "metal", "objc"]
 [dependencies]
 
 libloading = { version = "0.7", optional = true }
-raw-window-handle = { version = "0.3", optional = true }
+raw-window-handle = { version = "0.5", optional = true }
 vulkanalia-sys = { version = "0.17", path = "../vulkanalia-sys" }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/vulkanalia/src/window.rs
+++ b/vulkanalia/src/window.rs
@@ -50,13 +50,13 @@ pub fn get_required_instance_extensions(
         ],
         // macOS
         #[cfg(target_os = "macos")]
-        RawWindowHandle::MacOS(window) => &[
+        RawWindowHandle::AppKit(window) => &[
             &vk::KHR_SURFACE_EXTENSION.name,
             &vk::EXT_METAL_SURFACE_EXTENSION.name,
         ],
         // Windows
         #[cfg(target_os = "windows")]
-        RawWindowHandle::Windows(_) => &[
+        RawWindowHandle::Win32(_) => &[
             &vk::KHR_SURFACE_EXTENSION.name,
             &vk::KHR_WIN32_SURFACE_EXTENSION.name,
         ],


### PR DESCRIPTION
raw-window-handle 0.5 introduced [breaking changes](https://github.com/rust-windowing/raw-window-handle/blob/master/CHANGELOG.md#050-2022-07-14) from creating new traits (`[Has,]RawDisplayHandle`) and splitting the original `RawWindowHandle` into window and display handles which makes a difference in unix native protocols.

Since you cannot straight-forwardly add a constrain to a trait object I considered 2 alternatives:
1. Create a trait which combines `HasRaw[Window,Display]Handle` and changing the function signature to that trait, also probably expose it by default.
2. Add one argument for the display handle, changing the way you call `create_surface()`.

I ended up arbitrarily choosing the latter, but it should not be hard to implement the first approach (although I would personally remove the dynamic dispatch and just take a reference to a generic parameter which implements both traits, it's not like a program would use the function with many different window types).

I could only test this on Xlib, I could try Xcb, I don't know any "high level" library that uses it internally.