### PR TITLE
make it no_std compatible

### DIFF
--- a/generator/src/main/kotlin/com/kylemayes/generator/generate/file/Builders.kt
+++ b/generator/src/main/kotlin/com/kylemayes/generator/generate/file/Builders.kt
@@ -22,11 +22,11 @@ import com.kylemayes.generator.support.PeekableIterator
 /** Generates Rust structs to build Vulkan structs. */
 fun Registry.generateBuilders() =
     """
-use std::fmt;
-use std::marker::PhantomData;
-use std::ops;
-use std::os::raw::{c_char, c_int, c_void};
-use std::ptr::NonNull;
+use core::fmt;
+use core::marker::PhantomData;
+use core::ops;
+use core::ffi::{c_char, c_int, c_void};
+use core::ptr::NonNull;
 
 use super::*;
 

--- a/generator/src/main/kotlin/com/kylemayes/generator/generate/file/Chains.kt
+++ b/generator/src/main/kotlin/com/kylemayes/generator/generate/file/Chains.kt
@@ -10,7 +10,7 @@ import java.lang.Error
 
 fun Registry.generateChains(): String {
     return """
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use super::*;
 

--- a/generator/src/main/kotlin/com/kylemayes/generator/generate/file/Commands.kt
+++ b/generator/src/main/kotlin/com/kylemayes/generator/generate/file/Commands.kt
@@ -11,7 +11,7 @@ import com.kylemayes.generator.registry.Registry
 /** Generates Rust type aliases for Vulkan commands. */
 fun Registry.generateCommands() =
     """
-use std::os::raw::{c_char, c_int, c_void};
+use core::ffi::{c_char, c_int, c_void};
 
 use crate::*;
 
@@ -41,8 +41,8 @@ fun Registry.generateCommandStructs(): String {
             generateCommandStruct(it.key, supported)
         }
     return """
-use std::mem;
-use std::os::raw::{c_char, c_int, c_void};
+use core::mem;
+use core::ffi::{c_char, c_int, c_void};
 
 use super::*;
 

--- a/generator/src/main/kotlin/com/kylemayes/generator/generate/file/Enums.kt
+++ b/generator/src/main/kotlin/com/kylemayes/generator/generate/file/Enums.kt
@@ -12,8 +12,9 @@ import com.kylemayes.generator.registry.intern
 /** Generates Rust structs for Vulkan enums. */
 fun Registry.generateEnums() =
     """
-use std::error;
-use std::fmt;
+#[cfg(feature = "std")] use std::error;
+#[cfg(feature = "core_error")] use core::error;
+use core::fmt;
 
 ${enums.values.sortedBy { it.name }.joinToString("\n") { generateEnum(it) }}
 ${generateAliases(enums.keys)}
@@ -22,8 +23,9 @@ ${generateAliases(enums.keys)}
 /** Generates Rust structs for success result and error result enums. */
 fun Registry.generateResultEnums() =
     """
-use std::error;
-use std::fmt;
+#[cfg(feature = "std")] use std::error;
+#[cfg(feature = "core_error")] use core::error;
+use core::fmt;
 
 use super::Result;
 
@@ -68,7 +70,7 @@ private fun Registry.generateEnum(enum: Enum, documentation: String? = null): St
     val (display, error) = if (enum.name.value == "Result" || enum.name.value == "ErrorCode") {
         val default = "write!(f, \"unknown Vulkan result (code = {})\", self.0)"
         val display = generateFmtImpl(enum, "Display", default) { "\"${results[it.value] ?: it.name.value}\"" }
-        display to "impl error::Error for ${enum.name} { }"
+        display to "#[cfg(any(feature = \"core_error\", feature = \"std\"))] impl error::Error for ${enum.name} { }"
     } else {
         "" to ""
     }

--- a/generator/src/main/kotlin/com/kylemayes/generator/generate/file/Extensions.kt
+++ b/generator/src/main/kotlin/com/kylemayes/generator/generate/file/Extensions.kt
@@ -105,9 +105,9 @@ pub const ${extension.name}_EXTENSION: Extension = Extension {
 /** Generates Rust modules and traits for Vulkan extensions. */
 fun Registry.generateExtensionTraits() =
     """
-use std::mem::MaybeUninit;
-use std::os::raw::{c_int, c_void};
-use std::ptr;
+use core::mem::MaybeUninit;
+use core::ffi::{c_int, c_void};
+use core::ptr;
 
 use super::*;
 

--- a/generator/src/main/kotlin/com/kylemayes/generator/generate/file/Functions.kt
+++ b/generator/src/main/kotlin/com/kylemayes/generator/generate/file/Functions.kt
@@ -9,7 +9,7 @@ import com.kylemayes.generator.registry.Registry
 /** Generates Rust type aliases for Vulkan function pointer types. */
 fun Registry.generateFunctions() =
     """
-use std::os::raw::{c_char, c_void};
+use core::ffi::{c_char, c_void};
 
 use crate::*;
 

--- a/generator/src/main/kotlin/com/kylemayes/generator/generate/file/Handles.kt
+++ b/generator/src/main/kotlin/com/kylemayes/generator/generate/file/Handles.kt
@@ -11,8 +11,8 @@ import com.kylemayes.generator.support.toSnakeCase
 /** Generates Rust structs for Vulkan handles. */
 fun Registry.generateHandles() =
     """
-use std::fmt;
-use std::hash::Hash;
+use core::fmt;
+use core::hash::Hash;
 
 use crate::ObjectType;
 

--- a/generator/src/main/kotlin/com/kylemayes/generator/generate/file/Structs.kt
+++ b/generator/src/main/kotlin/com/kylemayes/generator/generate/file/Structs.kt
@@ -15,9 +15,9 @@ import com.kylemayes.generator.support.PeekableIterator
 /** Generates Rust structs for Vulkan structs. */
 fun Registry.generateStructs(): String {
     return """
-use std::fmt;
-use std::os::raw::{c_char, c_int, c_void};
-use std::ptr;
+use core::fmt;
+use core::ffi::{c_char, c_int, c_void};
+use core::ptr;
 
 use crate::*;
 

--- a/generator/src/main/kotlin/com/kylemayes/generator/generate/file/Typedefs.kt
+++ b/generator/src/main/kotlin/com/kylemayes/generator/generate/file/Typedefs.kt
@@ -9,7 +9,7 @@ import com.kylemayes.generator.registry.Typedef
 /** Generates Rust type aliases for Vulkan typedefs and platform types. */
 fun Registry.generateTypedefs() =
     """
-use std::os::raw::{c_ulong, c_void};
+use core::ffi::{c_ulong, c_void};
 
 ${basetypes.values.sortedBy { it.name }.joinToString("\n") { generateTypedef(it) }}
 

--- a/generator/src/main/kotlin/com/kylemayes/generator/generate/file/Unions.kt
+++ b/generator/src/main/kotlin/com/kylemayes/generator/generate/file/Unions.kt
@@ -10,9 +10,9 @@ import com.kylemayes.generator.registry.Structure
 /** Generates Rust unions for Vulkan unions. */
 fun Registry.generateUnions() =
     """
-use std::fmt;
-use std::mem::MaybeUninit;
-use std::os::raw::{c_char, c_void};
+use core::fmt;
+use core::mem::MaybeUninit;
+use core::ffi::{c_char, c_void};
 
 use crate::*;
 

--- a/generator/src/main/kotlin/com/kylemayes/generator/generate/file/Versions.kt
+++ b/generator/src/main/kotlin/com/kylemayes/generator/generate/file/Versions.kt
@@ -13,9 +13,9 @@ import com.kylemayes.generator.registry.Version
 fun Registry.generateVersionTraits(): String {
     var versions =
         """
-use std::mem::MaybeUninit;
-use std::os::raw::c_void;
-use std::ptr;
+use core::mem::MaybeUninit;
+use core::ffi::c_void;
+use core::ptr;
 
 use super::*;
         """

--- a/vulkanalia-sys/Cargo.toml
+++ b/vulkanalia-sys/Cargo.toml
@@ -20,7 +20,7 @@ categories = ["graphics"]
 
 [features]
 
-default = []
+default = ["std"]
 
 provisional = []
 

--- a/vulkanalia-sys/Cargo.toml
+++ b/vulkanalia-sys/Cargo.toml
@@ -20,7 +20,13 @@ categories = ["graphics"]
 
 [features]
 
+default = []
+
 provisional = []
+
+core_error = []
+
+std = []
 
 [dependencies]
 

--- a/vulkanalia-sys/src/arrays.rs
+++ b/vulkanalia-sys/src/arrays.rs
@@ -9,12 +9,13 @@
     clippy::upper_case_acronyms
 )]
 
-use std::borrow::Cow;
-use std::ffi::CStr;
-use std::fmt;
-use std::hash;
-use std::ops;
-use std::os::raw::c_char;
+use alloc::borrow::Cow;
+use alloc::string::String;
+use core::ffi::c_char;
+use core::ffi::CStr;
+use core::fmt;
+use core::hash;
+use core::ops;
 
 /// An array containing a sequence of bytes.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -88,7 +89,7 @@ impl<const N: usize> From<ByteArray<N>> for [u8; N] {
 ///
 /// assert_eq!(hasher1.finish(), hasher2.finish());
 /// ```
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Ord, PartialOrd)]
 #[repr(transparent)]
 pub struct StringArray<const N: usize>([c_char; N]);
 
@@ -244,8 +245,8 @@ impl<const N: usize> From<StringArray<N>> for [c_char; N] {
 mod test {
     use super::*;
 
+    use core::hash::{Hash, Hasher};
     use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
 
     fn hash(hash: impl Hash) -> u64 {
         let mut hasher = DefaultHasher::new();

--- a/vulkanalia-sys/src/bitfields.rs
+++ b/vulkanalia-sys/src/bitfields.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fmt;
+use core::fmt;
 
 /// A pair of bitfields stored in an `u32`.
 ///

--- a/vulkanalia-sys/src/commands.rs
+++ b/vulkanalia-sys/src/commands.rs
@@ -17,7 +17,7 @@
     clippy::useless_transmute
 )]
 
-use std::os::raw::{c_char, c_int, c_void};
+use core::ffi::{c_char, c_int, c_void};
 
 use crate::*;
 

--- a/vulkanalia-sys/src/enums.rs
+++ b/vulkanalia-sys/src/enums.rs
@@ -17,8 +17,9 @@
     clippy::useless_transmute
 )]
 
-use std::error;
-use std::fmt;
+#[cfg(feature = "core_error")] use core::error;
+#[cfg(feature = "std")] use std::error;
+use core::fmt;
 
 /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkAccelerationStructureBuildTypeKHR.html>
 #[repr(transparent)]
@@ -4444,6 +4445,7 @@ impl fmt::Display for Result {
     }
 }
 
+#[cfg(any(feature = "core_error", feature = "std"))]
 impl error::Error for Result {}
 
 /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkSamplerAddressMode.html>

--- a/vulkanalia-sys/src/functions.rs
+++ b/vulkanalia-sys/src/functions.rs
@@ -17,7 +17,7 @@
     clippy::useless_transmute
 )]
 
-use std::os::raw::{c_char, c_void};
+use core::ffi::{c_char, c_void};
 
 use crate::*;
 

--- a/vulkanalia-sys/src/handles.rs
+++ b/vulkanalia-sys/src/handles.rs
@@ -17,8 +17,8 @@
     clippy::useless_transmute
 )]
 
-use std::fmt;
-use std::hash::Hash;
+use core::fmt;
+use core::hash::Hash;
 
 use crate::ObjectType;
 

--- a/vulkanalia-sys/src/lib.rs
+++ b/vulkanalia-sys/src/lib.rs
@@ -2,6 +2,11 @@
 
 //! Raw Vulkan bindings for Rust.
 
+#![cfg_attr(feature = "core_error", feature(error_in_core))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
 mod arrays;
 mod bitfields;
 

--- a/vulkanalia-sys/src/structs.rs
+++ b/vulkanalia-sys/src/structs.rs
@@ -17,9 +17,9 @@
     clippy::useless_transmute
 )]
 
-use std::fmt;
-use std::os::raw::{c_char, c_int, c_void};
-use std::ptr;
+use core::fmt;
+use core::ffi::{c_char, c_int, c_void};
+use core::ptr;
 
 use crate::*;
 

--- a/vulkanalia-sys/src/typedefs.rs
+++ b/vulkanalia-sys/src/typedefs.rs
@@ -17,7 +17,7 @@
     clippy::useless_transmute
 )]
 
-use std::os::raw::{c_ulong, c_void};
+use core::ffi::{c_ulong, c_void};
 
 /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkBool32.html>
 pub type Bool32 = u32;

--- a/vulkanalia-sys/src/unions.rs
+++ b/vulkanalia-sys/src/unions.rs
@@ -17,9 +17,9 @@
     clippy::useless_transmute
 )]
 
-use std::fmt;
-use std::mem::MaybeUninit;
-use std::os::raw::{c_char, c_void};
+use core::fmt;
+use core::mem::MaybeUninit;
+use core::ffi::{c_char, c_void};
 
 use crate::*;
 

--- a/vulkanalia/Cargo.toml
+++ b/vulkanalia/Cargo.toml
@@ -20,8 +20,11 @@ categories = ["graphics"]
 
 [features]
 
+default = ["std"]
 provisional = ["vulkanalia-sys/provisional"]
 window = ["raw-window-handle", "cocoa", "metal", "objc"]
+std = []
+core_error = []
 
 [dependencies]
 

--- a/vulkanalia/Cargo.toml
+++ b/vulkanalia/Cargo.toml
@@ -23,14 +23,14 @@ categories = ["graphics"]
 default = ["std"]
 provisional = ["vulkanalia-sys/provisional"]
 window = ["raw-window-handle", "cocoa", "metal", "objc"]
-std = []
-core_error = []
+std = ["vulkanalia-sys/std"]
+core_error = ["vulkanalia-sys/core_error"]
 
 [dependencies]
 
 libloading = { version = "0.7", optional = true }
 raw-window-handle = { version = "0.5", optional = true }
-vulkanalia-sys = { version = "0.21", path = "../vulkanalia-sys" }
+vulkanalia-sys = { version = "0.21", path = "../vulkanalia-sys", default-features = false }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 

--- a/vulkanalia/src/chain.rs
+++ b/vulkanalia/src/chain.rs
@@ -81,9 +81,9 @@
 //! assert_eq!(full.descriptor_indexing, 1);
 //! ```
 
-use std::iter;
-use std::os::raw::c_void;
-use std::ptr::NonNull;
+use core::ffi::c_void;
+use core::iter;
+use core::ptr::NonNull;
 
 use crate::prelude::v1_0::*;
 

--- a/vulkanalia/src/loader.rs
+++ b/vulkanalia/src/loader.rs
@@ -7,6 +7,8 @@ use core::error;
 #[cfg(feature = "std")]
 use std::error;
 
+use alloc::boxed::Box;
+
 /// The default Vulkan shared library filename on the current platform (Windows).
 #[cfg(windows)]
 pub const LIBRARY: &str = "vulkan-1.dll";

--- a/vulkanalia/src/loader.rs
+++ b/vulkanalia/src/loader.rs
@@ -2,6 +2,9 @@
 
 //! Vulkan function loaders.
 
+#[cfg(feature = "core_error")]
+use core::error;
+#[cfg(feature = "std")]
 use std::error;
 
 /// The default Vulkan shared library filename on the current platform (Windows).

--- a/vulkanalia/src/vk/builders.rs
+++ b/vulkanalia/src/vk/builders.rs
@@ -17,11 +17,11 @@
     clippy::useless_transmute
 )]
 
-use std::fmt;
-use std::marker::PhantomData;
-use std::ops;
-use std::os::raw::{c_char, c_int, c_void};
-use std::ptr::NonNull;
+use core::fmt;
+use core::marker::PhantomData;
+use core::ops;
+use core::ffi::{c_char, c_int, c_void};
+use core::ptr::NonNull;
 
 use super::*;
 

--- a/vulkanalia/src/vk/chains.rs
+++ b/vulkanalia/src/vk/chains.rs
@@ -17,7 +17,7 @@
     clippy::useless_transmute
 )]
 
-use std::os::raw::c_void;
+use core::ffi::c_void;
 
 use super::*;
 

--- a/vulkanalia/src/vk/commands.rs
+++ b/vulkanalia/src/vk/commands.rs
@@ -17,8 +17,8 @@
     clippy::useless_transmute
 )]
 
-use std::mem;
-use std::os::raw::{c_char, c_int, c_void};
+use core::mem;
+use core::ffi::{c_char, c_int, c_void};
 
 use super::*;
 

--- a/vulkanalia/src/vk/enums.rs
+++ b/vulkanalia/src/vk/enums.rs
@@ -17,8 +17,9 @@
     clippy::useless_transmute
 )]
 
-use std::error;
-use std::fmt;
+#[cfg(feature = "core_error")] use core::error;
+#[cfg(feature = "std")] use std::error;
+use core::fmt;
 
 use super::Result;
 
@@ -207,6 +208,7 @@ impl fmt::Display for ErrorCode {
     }
 }
 
+#[cfg(any(feature = "std", feature = "core_error"))]
 impl error::Error for ErrorCode {}
 
 impl From<Result> for ErrorCode {

--- a/vulkanalia/src/vk/extensions.rs
+++ b/vulkanalia/src/vk/extensions.rs
@@ -17,9 +17,9 @@
     clippy::useless_transmute
 )]
 
-use std::mem::MaybeUninit;
-use std::os::raw::{c_int, c_void};
-use std::ptr;
+use core::mem::MaybeUninit;
+use core::ffi::{c_int, c_void};
+use core::ptr;
 
 use super::*;
 

--- a/vulkanalia/src/vk/mod.rs
+++ b/vulkanalia/src/vk/mod.rs
@@ -23,3 +23,6 @@ pub use self::commands::*;
 pub use self::enums::*;
 pub use self::extensions::*;
 pub use self::versions::*;
+
+pub use alloc::boxed::Box;
+pub use alloc::vec::Vec;

--- a/vulkanalia/src/vk/versions.rs
+++ b/vulkanalia/src/vk/versions.rs
@@ -17,9 +17,9 @@
     clippy::useless_transmute
 )]
 
-use std::mem::MaybeUninit;
-use std::os::raw::c_void;
-use std::ptr;
+use core::mem::MaybeUninit;
+use core::ffi::c_void;
+use core::ptr;
 
 use super::*;
 

--- a/vulkanalia/src/window.rs
+++ b/vulkanalia/src/window.rs
@@ -126,8 +126,8 @@ pub unsafe fn create_surface(
         // macOS
         #[cfg(target_os = "macos")]
         (RawDisplayHandle::AppKit(_), RawWindowHandle::AppKit(window)) => {
-            use std::mem;
-            use std::os::raw::c_void;
+            use core::ffi::c_void;
+            use core::mem;
 
             use cocoa::appkit::{NSView, NSWindow};
             use cocoa::base::id;


### PR DESCRIPTION
This PR will convert almost all `std` artifacts to `core`, with the benefits of:

1. Much bigger expose, so low level users can also use this now
2. Also comes with \#1, I can use it to write intros ;P

There are some ABI breaking changes, notably the change from `HashSet` to `BTreeSet`, because this requires `hashbrown`, rather than having it from `alloc` out of the box. I think using BTreeSet shouldn't hurt much either. It also comes with an added benefit of lexicographically sorted (or UTF-8 binary order sorted)

This would still require `alloc`, due to the intense usages of `Vec` and `Box`