### PR TITLE
Tutorial: Fix broken check for format in match statement

### DIFF
--- a/tutorial/book/src/model/depth_buffering.md
+++ b/tutorial/book/src/model/depth_buffering.md
@@ -353,7 +353,7 @@ The undefined layout can be used as initial layout, because there are no existin
 ```rust,noplaypen
 let aspect_mask = if new_layout == vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL {
     match format {
-        vk::Format::D32_SFLOAT_S8_UINT | vk::Format::D24_UNORM_S8_UINT =>
+        vk::Format::D32_SFLOAT_S8_UINT || vk::Format::D24_UNORM_S8_UINT =>
             vk::ImageAspectFlags::DEPTH | vk::ImageAspectFlags::STENCIL,
         _ => vk::ImageAspectFlags::DEPTH
     }


### PR DESCRIPTION
We want the check to succeed if `format` is `D32_SFLOAT_S8_UINT` or `D24_UNORM_S8_UINT`, so the operator should be logical OR, not bitwise OR.