### PR TITLE
Fix correction matrix in tutorial

### DIFF
--- a/tutorial/book/src/model/depth_buffering.md
+++ b/tutorial/book/src/model/depth_buffering.md
@@ -122,7 +122,7 @@ let correction = Mat4::new(
     // We're also flipping the Y-axis with this line's `-1.0`.
     0.0, -1.0,       0.0, 0.0,
     0.0,  0.0, 1.0 / 2.0, 0.0,
-    0.0,  0.0, 1.0 / 2.0, 0.0,
+    0.0,  0.0, 1.0 / 2.0, 1.0,
 );
 
 let proj = correction


### PR DESCRIPTION
The last number in the correction matrix should be 1.0 not 0.0. This is likely a typo as the transposed correction matrix in the tutorial just beneath the correction matrix, and the "main.rs" code file, are both correct.