### PR TITLE
Replace reference to attrib.vertices in tutorial

### DIFF
--- a/tutorial/book/src/model/loading_models.md
+++ b/tutorial/book/src/model/loading_models.md
@@ -161,7 +161,7 @@ let vertex = Vertex {
 };
 ```
 
-Unfortunately the `attrib.vertices` array is an array of `float` values instead of something like `cgmath::Vector3<f32>`, so you need to multiply the index by `3`. Similarly, there are two texture coordinate components per entry. The offsets of `0`, `1` and `2` are used to access the X, Y and Z components, or the U and V components in the case of texture coordinates.
+Unfortunately, the `positions` returned from `tobj::load_obj_buf` are a flat array of `f32` values instead of something like `cgmath::Vector3<f32>`, so you need to multiply the index by `3` to account for each position having three components. Similarly, there are two texture coordinate components per entry. The offsets of `0`, `1` and `2` are used to access the X, Y and Z components, or the U and V components in the case of texture coordinates.
 
 You may want to start compiling your program in release mode from now on because loading the texture and model can be quite slow without optimizations. If you run your program now you should see something like the following:
 


### PR DESCRIPTION
The upstream Vulkan tutorial discusses attrib.vertices, but this structure is not relevant to Vulkanalia, so improve the wording.