### PR TITLE
Restore original rotation speed in tutorial

### DIFF
--- a/tutorial/book/src/dynamic/recycling_command_buffers.md
+++ b/tutorial/book/src/dynamic/recycling_command_buffers.md
@@ -151,7 +151,7 @@ let time = self.start.elapsed().as_secs_f32();
 
 let model = Mat4::from_axis_angle(
     vec3(0.0, 0.0, 1.0),
-    Deg(0.0) * time
+    Deg(90.0) * time
 );
 
 let model_bytes = &*slice_from_raw_parts(


### PR DESCRIPTION
The current code leaves the rotation speed as 0.0 degrees per second, i.e., no rotation, rather than restoring it to 90.0 as the text above the code implies.