### PR TITLE
Add white background for SVG images

### DIFF
--- a/tutorial/book/src/images/extra_square.svg
+++ b/tutorial/book/src/images/extra_square.svg
@@ -74,6 +74,7 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <rect width="100%" height="100%" fill="white" />
   <g
      inkscape:groupmode="layer"
      id="layer3"

--- a/tutorial/book/src/images/normalized_device_coordinates.svg
+++ b/tutorial/book/src/images/normalized_device_coordinates.svg
@@ -52,6 +52,7 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <rect width="100%" height="100%" fill="white" />
   <g
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"

--- a/tutorial/book/src/images/triangle_coordinates.svg
+++ b/tutorial/book/src/images/triangle_coordinates.svg
@@ -52,6 +52,7 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <rect width="100%" height="100%" fill="white" />
   <g
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"

--- a/tutorial/book/src/images/vertex_vs_index.svg
+++ b/tutorial/book/src/images/vertex_vs_index.svg
@@ -52,6 +52,7 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <rect width="100%" height="100%" fill="white" />
   <g
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"

--- a/tutorial/book/src/images/vulkan_simplified_pipeline.svg
+++ b/tutorial/book/src/images/vulkan_simplified_pipeline.svg
@@ -151,6 +151,7 @@
        gradientTransform="scale(1.7179114,0.5821022)"
        gradientUnits="userSpaceOnUse" />
   </defs>
+  <rect width="100%" height="100%" fill="white" />
   <g
      transform="translate(0.5,0.5)"
      id="g16">


### PR DESCRIPTION
Currently, SVG images in the tutorial have transparent background, which makes these images somewhat not readable when editing with a dark-themed editor and when reading with a dark mdbook theme enabled:

<details>
<summary>(VSCode, GitHub Dark Colorblind)</summary>
<img src="https://github.com/KyleMayes/vulkanalia/assets/29348140/c3050029-e5b8-4731-803d-93ee2f89a0f3" />
</details>

<details>
<summary>(mdbook theme ayu)</summary>
<img src="https://github.com/KyleMayes/vulkanalia/assets/29348140/8e98473c-2ca5-46c2-bbdc-d4f062fd9706" />
</details>

This pull request would add a white background for these SVG images, somewhat improving reading experience.