### PR TITLE
Fix "tobj" wikipedia link

### DIFF
--- a/tutorial/book/src/development_environment.md
+++ b/tutorial/book/src/development_environment.md
@@ -30,7 +30,7 @@ winit = "0.28"
 * `png` &ndash; used to load PNGs to use as textures
 * `pretty_env_logger` &ndash; used to print our logs to the console
 * `thiserror` &ndash; used to define custom errors types without boilerplate
-* `tobj` &ndash; used to load 3D models in the [Wavefront .obj format](https:/en.wikipedia.org/wiki/Wavefront_.obj_file)
+* `tobj` &ndash; used to load 3D models in the [Wavefront .obj format](https://en.wikipedia.org/wiki/Wavefront_.obj_file)
 * `vulkanalia` &ndash; used to call the Vulkan API
 * `winit` &ndash; used to create a window to render to
 


### PR DESCRIPTION
Hello, as a new reader I found the issue with a link (missing `/` in `https://`) on the [development environment page](https://kylemayes.github.io/vulkanalia/development_environment.html), so I decided to fix it for you ^^

![image](https://github.com/KyleMayes/vulkanalia/assets/28712303/ab2920e9-5b81-4f8e-b49f-fb6744b97533)
