### PR TITLE
Type check error fix: Explicitly build DeviceQueueCreateInfo within queue_infos

### DIFF
--- a/tutorial/book/src/presentation/window_surface.md
+++ b/tutorial/book/src/presentation/window_surface.md
@@ -145,6 +145,7 @@ let queue_infos = unique_indices
         vk::DeviceQueueCreateInfo::builder()
             .queue_family_index(*i)
             .queue_priorities(queue_priorities)
+            .build()
     })
     .collect::<Vec<_>>();
 ```


### PR DESCRIPTION
This failed to type check without an explicit call to `build()` when trying to pass this into `queue_create_infos`


    let info = vk::DeviceCreateInfo::builder()
        .queue_create_infos(&queue_infos) // type error without this fix
        .enabled_layer_names(&layers)
        .enabled_extension_names(&extensions)
        .enabled_features(&features);

