### PR TITLE
Fix upstream links being 404s by linking to /latest/ instead of /1.4-extensions/

### DIFF
--- a/generator/src/main/kotlin/com/kylemayes/generator/generate/support/Manual.kt
+++ b/generator/src/main/kotlin/com/kylemayes/generator/generate/support/Manual.kt
@@ -8,15 +8,12 @@ import com.kylemayes.generator.registry.Registry
 /** The generated URLs for Vulkan manual pages. */
 val manualUrls = mutableListOf<Pair<String, String>>()
 
-private val getLatestVersionNumber = thunk { -> versions.values.maxOfOrNull { it.number }!! }
-
 /** Generates a URL for a Vulkan manual page for a Vulkan entity. */
 fun Registry.generateManualUrl(entity: Entity) = generateManualUrl(entity.name.original)
 
 /** Generates a URL for a Vulkan manual page for a Vulkan entity. */
 fun Registry.generateManualUrl(name: String): String {
-    val version = getLatestVersionNumber()
-    val url = "https://www.khronos.org/registry/vulkan/specs/$version-extensions/man/html/$name.html"
+    val url = "https://www.khronos.org/registry/vulkan/specs/latest/man/html/$name.html"
     manualUrls.add(name to url)
     return url
 }


### PR DESCRIPTION
Closes: #313