### PR TITLE
Sets code_size for shader module creation

### DIFF
--- a/tutorial/book/src/pipeline/shader_modules.md
+++ b/tutorial/book/src/pipeline/shader_modules.md
@@ -231,7 +231,8 @@ We can then construct a `vk::ShaderModuleCreateInfo` and use it to call `create_
 
 ```rust,noplaypen
 let info = vk::ShaderModuleCreateInfo::builder()
-    .code(bytecode.code());
+    .code(bytecode.code())
+    .code_size(bytecode.code_size());
 
 Ok(device.create_shader_module(&info, None)?)
 ```

--- a/tutorial/src/09_shader_modules.rs
+++ b/tutorial/src/09_shader_modules.rs
@@ -524,7 +524,9 @@ unsafe fn create_pipeline(device: &Device, data: &mut AppData) -> Result<()> {
 
 unsafe fn create_shader_module(device: &Device, bytecode: &[u8]) -> Result<vk::ShaderModule> {
     let bytecode = Bytecode::new(bytecode).unwrap();
-    let info = vk::ShaderModuleCreateInfo::builder().code(bytecode.code());
+    let info = vk::ShaderModuleCreateInfo::builder()
+        .code(bytecode.code())
+        .code_size(bytecode.code_size());
     Ok(device.create_shader_module(&info, None)?)
 }
 

--- a/tutorial/src/10_fixed_functions.rs
+++ b/tutorial/src/10_fixed_functions.rs
@@ -593,7 +593,9 @@ unsafe fn create_pipeline(device: &Device, data: &mut AppData) -> Result<()> {
 
 unsafe fn create_shader_module(device: &Device, bytecode: &[u8]) -> Result<vk::ShaderModule> {
     let bytecode = Bytecode::new(bytecode).unwrap();
-    let info = vk::ShaderModuleCreateInfo::builder().code(bytecode.code());
+    let info = vk::ShaderModuleCreateInfo::builder()
+        .code(bytecode.code())
+        .code_size(bytecode.code_size());
     Ok(device.create_shader_module(&info, None)?)
 }
 

--- a/tutorial/src/11_render_passes.rs
+++ b/tutorial/src/11_render_passes.rs
@@ -633,7 +633,9 @@ unsafe fn create_pipeline(device: &Device, data: &mut AppData) -> Result<()> {
 
 unsafe fn create_shader_module(device: &Device, bytecode: &[u8]) -> Result<vk::ShaderModule> {
     let bytecode = Bytecode::new(bytecode).unwrap();
-    let info = vk::ShaderModuleCreateInfo::builder().code(bytecode.code());
+    let info = vk::ShaderModuleCreateInfo::builder()
+        .code(bytecode.code())
+        .code_size(bytecode.code_size());
     Ok(device.create_shader_module(&info, None)?)
 }
 

--- a/tutorial/src/12_graphics_pipeline_complete.rs
+++ b/tutorial/src/12_graphics_pipeline_complete.rs
@@ -654,7 +654,9 @@ unsafe fn create_pipeline(device: &Device, data: &mut AppData) -> Result<()> {
 
 unsafe fn create_shader_module(device: &Device, bytecode: &[u8]) -> Result<vk::ShaderModule> {
     let bytecode = Bytecode::new(bytecode).unwrap();
-    let info = vk::ShaderModuleCreateInfo::builder().code(bytecode.code());
+    let info = vk::ShaderModuleCreateInfo::builder()
+        .code(bytecode.code())
+        .code_size(bytecode.code_size());
     Ok(device.create_shader_module(&info, None)?)
 }
 

--- a/tutorial/src/13_framebuffers.rs
+++ b/tutorial/src/13_framebuffers.rs
@@ -658,7 +658,9 @@ unsafe fn create_pipeline(device: &Device, data: &mut AppData) -> Result<()> {
 
 unsafe fn create_shader_module(device: &Device, bytecode: &[u8]) -> Result<vk::ShaderModule> {
     let bytecode = Bytecode::new(bytecode).unwrap();
-    let info = vk::ShaderModuleCreateInfo::builder().code(bytecode.code());
+    let info = vk::ShaderModuleCreateInfo::builder()
+        .code(bytecode.code())
+        .code_size(bytecode.code_size());
     Ok(device.create_shader_module(&info, None)?)
 }
 

--- a/tutorial/src/14_command_buffers.rs
+++ b/tutorial/src/14_command_buffers.rs
@@ -665,7 +665,9 @@ unsafe fn create_pipeline(device: &Device, data: &mut AppData) -> Result<()> {
 
 unsafe fn create_shader_module(device: &Device, bytecode: &[u8]) -> Result<vk::ShaderModule> {
     let bytecode = Bytecode::new(bytecode).unwrap();
-    let info = vk::ShaderModuleCreateInfo::builder().code(bytecode.code());
+    let info = vk::ShaderModuleCreateInfo::builder()
+        .code(bytecode.code())
+        .code_size(bytecode.code_size());
     Ok(device.create_shader_module(&info, None)?)
 }
 

--- a/tutorial/src/15_hello_triangle.rs
+++ b/tutorial/src/15_hello_triangle.rs
@@ -740,7 +740,9 @@ unsafe fn create_pipeline(device: &Device, data: &mut AppData) -> Result<()> {
 
 unsafe fn create_shader_module(device: &Device, bytecode: &[u8]) -> Result<vk::ShaderModule> {
     let bytecode = Bytecode::new(bytecode).unwrap();
-    let info = vk::ShaderModuleCreateInfo::builder().code(bytecode.code());
+    let info = vk::ShaderModuleCreateInfo::builder()
+        .code(bytecode.code())
+        .code_size(bytecode.code_size());
     Ok(device.create_shader_module(&info, None)?)
 }
 

--- a/tutorial/src/16_swapchain_recreation.rs
+++ b/tutorial/src/16_swapchain_recreation.rs
@@ -787,7 +787,9 @@ unsafe fn create_pipeline(device: &Device, data: &mut AppData) -> Result<()> {
 
 unsafe fn create_shader_module(device: &Device, bytecode: &[u8]) -> Result<vk::ShaderModule> {
     let bytecode = Bytecode::new(bytecode).unwrap();
-    let info = vk::ShaderModuleCreateInfo::builder().code(bytecode.code());
+    let info = vk::ShaderModuleCreateInfo::builder()
+        .code(bytecode.code())
+        .code_size(bytecode.code_size());
     Ok(device.create_shader_module(&info, None)?)
 }
 

--- a/tutorial/src/17_vertex_input.rs
+++ b/tutorial/src/17_vertex_input.rs
@@ -803,7 +803,9 @@ unsafe fn create_pipeline(device: &Device, data: &mut AppData) -> Result<()> {
 
 unsafe fn create_shader_module(device: &Device, bytecode: &[u8]) -> Result<vk::ShaderModule> {
     let bytecode = Bytecode::new(bytecode).unwrap();
-    let info = vk::ShaderModuleCreateInfo::builder().code(bytecode.code());
+    let info = vk::ShaderModuleCreateInfo::builder()
+        .code(bytecode.code())
+        .code_size(bytecode.code_size());
     Ok(device.create_shader_module(&info, None)?)
 }
 

--- a/tutorial/src/18_vertex_buffer.rs
+++ b/tutorial/src/18_vertex_buffer.rs
@@ -810,7 +810,9 @@ unsafe fn create_pipeline(device: &Device, data: &mut AppData) -> Result<()> {
 
 unsafe fn create_shader_module(device: &Device, bytecode: &[u8]) -> Result<vk::ShaderModule> {
     let bytecode = Bytecode::new(bytecode).unwrap();
-    let info = vk::ShaderModuleCreateInfo::builder().code(bytecode.code());
+    let info = vk::ShaderModuleCreateInfo::builder()
+        .code(bytecode.code())
+        .code_size(bytecode.code_size());
     Ok(device.create_shader_module(&info, None)?)
 }
 

--- a/tutorial/src/19_staging_buffer.rs
+++ b/tutorial/src/19_staging_buffer.rs
@@ -810,7 +810,9 @@ unsafe fn create_pipeline(device: &Device, data: &mut AppData) -> Result<()> {
 
 unsafe fn create_shader_module(device: &Device, bytecode: &[u8]) -> Result<vk::ShaderModule> {
     let bytecode = Bytecode::new(bytecode).unwrap();
-    let info = vk::ShaderModuleCreateInfo::builder().code(bytecode.code());
+    let info = vk::ShaderModuleCreateInfo::builder()
+        .code(bytecode.code())
+        .code_size(bytecode.code_size());
     Ok(device.create_shader_module(&info, None)?)
 }
 

--- a/tutorial/src/20_index_buffer.rs
+++ b/tutorial/src/20_index_buffer.rs
@@ -818,7 +818,9 @@ unsafe fn create_pipeline(device: &Device, data: &mut AppData) -> Result<()> {
 
 unsafe fn create_shader_module(device: &Device, bytecode: &[u8]) -> Result<vk::ShaderModule> {
     let bytecode = Bytecode::new(bytecode).unwrap();
-    let info = vk::ShaderModuleCreateInfo::builder().code(bytecode.code());
+    let info = vk::ShaderModuleCreateInfo::builder()
+        .code(bytecode.code())
+        .code_size(bytecode.code_size());
     Ok(device.create_shader_module(&info, None)?)
 }
 

--- a/tutorial/src/21_descriptor_set_layout.rs
+++ b/tutorial/src/21_descriptor_set_layout.rs
@@ -890,7 +890,9 @@ unsafe fn create_pipeline(device: &Device, data: &mut AppData) -> Result<()> {
 
 unsafe fn create_shader_module(device: &Device, bytecode: &[u8]) -> Result<vk::ShaderModule> {
     let bytecode = Bytecode::new(bytecode).unwrap();
-    let info = vk::ShaderModuleCreateInfo::builder().code(bytecode.code());
+    let info = vk::ShaderModuleCreateInfo::builder()
+        .code(bytecode.code())
+        .code_size(bytecode.code_size());
     Ok(device.create_shader_module(&info, None)?)
 }
 

--- a/tutorial/src/22_descriptor_sets.rs
+++ b/tutorial/src/22_descriptor_sets.rs
@@ -898,7 +898,9 @@ unsafe fn create_pipeline(device: &Device, data: &mut AppData) -> Result<()> {
 
 unsafe fn create_shader_module(device: &Device, bytecode: &[u8]) -> Result<vk::ShaderModule> {
     let bytecode = Bytecode::new(bytecode).unwrap();
-    let info = vk::ShaderModuleCreateInfo::builder().code(bytecode.code());
+    let info = vk::ShaderModuleCreateInfo::builder()
+        .code(bytecode.code())
+        .code_size(bytecode.code_size());
     Ok(device.create_shader_module(&info, None)?)
 }
 

--- a/tutorial/src/23_texture_image.rs
+++ b/tutorial/src/23_texture_image.rs
@@ -905,7 +905,9 @@ unsafe fn create_pipeline(device: &Device, data: &mut AppData) -> Result<()> {
 
 unsafe fn create_shader_module(device: &Device, bytecode: &[u8]) -> Result<vk::ShaderModule> {
     let bytecode = Bytecode::new(bytecode).unwrap();
-    let info = vk::ShaderModuleCreateInfo::builder().code(bytecode.code());
+    let info = vk::ShaderModuleCreateInfo::builder()
+        .code(bytecode.code())
+        .code_size(bytecode.code_size());
     Ok(device.create_shader_module(&info, None)?)
 }
 

--- a/tutorial/src/24_sampler.rs
+++ b/tutorial/src/24_sampler.rs
@@ -894,7 +894,9 @@ unsafe fn create_pipeline(device: &Device, data: &mut AppData) -> Result<()> {
 
 unsafe fn create_shader_module(device: &Device, bytecode: &[u8]) -> Result<vk::ShaderModule> {
     let bytecode = Bytecode::new(bytecode).unwrap();
-    let info = vk::ShaderModuleCreateInfo::builder().code(bytecode.code());
+    let info = vk::ShaderModuleCreateInfo::builder()
+        .code(bytecode.code())
+        .code_size(bytecode.code_size());
     Ok(device.create_shader_module(&info, None)?)
 }
 

--- a/tutorial/src/25_texture_mapping.rs
+++ b/tutorial/src/25_texture_mapping.rs
@@ -900,7 +900,9 @@ unsafe fn create_pipeline(device: &Device, data: &mut AppData) -> Result<()> {
 
 unsafe fn create_shader_module(device: &Device, bytecode: &[u8]) -> Result<vk::ShaderModule> {
     let bytecode = Bytecode::new(bytecode).unwrap();
-    let info = vk::ShaderModuleCreateInfo::builder().code(bytecode.code());
+    let info = vk::ShaderModuleCreateInfo::builder()
+        .code(bytecode.code())
+        .code_size(bytecode.code_size());
     Ok(device.create_shader_module(&info, None)?)
 }
 

--- a/tutorial/src/26_depth_buffering.rs
+++ b/tutorial/src/26_depth_buffering.rs
@@ -951,7 +951,9 @@ unsafe fn create_pipeline(device: &Device, data: &mut AppData) -> Result<()> {
 
 unsafe fn create_shader_module(device: &Device, bytecode: &[u8]) -> Result<vk::ShaderModule> {
     let bytecode = Bytecode::new(bytecode).unwrap();
-    let info = vk::ShaderModuleCreateInfo::builder().code(bytecode.code());
+    let info = vk::ShaderModuleCreateInfo::builder()
+        .code(bytecode.code())
+        .code_size(bytecode.code_size());
     Ok(device.create_shader_module(&info, None)?)
 }
 

--- a/tutorial/src/27_model_loading.rs
+++ b/tutorial/src/27_model_loading.rs
@@ -937,7 +937,9 @@ unsafe fn create_pipeline(device: &Device, data: &mut AppData) -> Result<()> {
 
 unsafe fn create_shader_module(device: &Device, bytecode: &[u8]) -> Result<vk::ShaderModule> {
     let bytecode = Bytecode::new(bytecode).unwrap();
-    let info = vk::ShaderModuleCreateInfo::builder().code(bytecode.code());
+    let info = vk::ShaderModuleCreateInfo::builder()
+        .code(bytecode.code())
+        .code_size(bytecode.code_size());
     Ok(device.create_shader_module(&info, None)?)
 }
 

--- a/tutorial/src/28_mipmapping.rs
+++ b/tutorial/src/28_mipmapping.rs
@@ -938,7 +938,9 @@ unsafe fn create_pipeline(device: &Device, data: &mut AppData) -> Result<()> {
 
 unsafe fn create_shader_module(device: &Device, bytecode: &[u8]) -> Result<vk::ShaderModule> {
     let bytecode = Bytecode::new(bytecode).unwrap();
-    let info = vk::ShaderModuleCreateInfo::builder().code(bytecode.code());
+    let info = vk::ShaderModuleCreateInfo::builder()
+        .code(bytecode.code())
+        .code_size(bytecode.code_size());
     Ok(device.create_shader_module(&info, None)?)
 }
 

--- a/tutorial/src/29_multisampling.rs
+++ b/tutorial/src/29_multisampling.rs
@@ -985,7 +985,9 @@ unsafe fn create_pipeline(device: &Device, data: &mut AppData) -> Result<()> {
 
 unsafe fn create_shader_module(device: &Device, bytecode: &[u8]) -> Result<vk::ShaderModule> {
     let bytecode = Bytecode::new(bytecode).unwrap();
-    let info = vk::ShaderModuleCreateInfo::builder().code(bytecode.code());
+    let info = vk::ShaderModuleCreateInfo::builder()
+        .code(bytecode.code())
+        .code_size(bytecode.code_size());
     Ok(device.create_shader_module(&info, None)?)
 }
 

--- a/tutorial/src/30_push_constants.rs
+++ b/tutorial/src/30_push_constants.rs
@@ -1002,7 +1002,9 @@ unsafe fn create_pipeline(device: &Device, data: &mut AppData) -> Result<()> {
 
 unsafe fn create_shader_module(device: &Device, bytecode: &[u8]) -> Result<vk::ShaderModule> {
     let bytecode = Bytecode::new(bytecode).unwrap();
-    let info = vk::ShaderModuleCreateInfo::builder().code(bytecode.code());
+    let info = vk::ShaderModuleCreateInfo::builder()
+        .code(bytecode.code())
+        .code_size(bytecode.code_size());
     Ok(device.create_shader_module(&info, None)?)
 }
 

--- a/tutorial/src/31_recycling_command_buffers.rs
+++ b/tutorial/src/31_recycling_command_buffers.rs
@@ -1086,7 +1086,9 @@ unsafe fn create_pipeline(device: &Device, data: &mut AppData) -> Result<()> {
 
 unsafe fn create_shader_module(device: &Device, bytecode: &[u8]) -> Result<vk::ShaderModule> {
     let bytecode = Bytecode::new(bytecode).unwrap();
-    let info = vk::ShaderModuleCreateInfo::builder().code(bytecode.code());
+    let info = vk::ShaderModuleCreateInfo::builder()
+        .code(bytecode.code())
+        .code_size(bytecode.code_size());
     Ok(device.create_shader_module(&info, None)?)
 }
 

--- a/tutorial/src/32_secondary_command_buffers.rs
+++ b/tutorial/src/32_secondary_command_buffers.rs
@@ -1153,7 +1153,9 @@ unsafe fn create_pipeline(device: &Device, data: &mut AppData) -> Result<()> {
 
 unsafe fn create_shader_module(device: &Device, bytecode: &[u8]) -> Result<vk::ShaderModule> {
     let bytecode = Bytecode::new(bytecode).unwrap();
-    let info = vk::ShaderModuleCreateInfo::builder().code(bytecode.code());
+    let info = vk::ShaderModuleCreateInfo::builder()
+        .code(bytecode.code())
+        .code_size(bytecode.code_size());
     Ok(device.create_shader_module(&info, None)?)
 }
 


### PR DESCRIPTION
This reverts #320, but the code size is required:

```
 ERROR 19_staging_buffer > (VALIDATION) Validation Error: [ VUID-VkShaderModuleCreateInfo-codeSize-01085 ] | MessageID = 0x89399f53 | vkCreateShaderModule(): pCreateInfo->codeSize must be greater than 0.
The Vulkan spec states: codeSize must be greater than 0 (https://docs.vulkan.org/spec/latest/chapters/shaders.html#VUID-VkShaderModuleCreateInfo-codeSize-01085)
 ERROR 19_staging_buffer > (VALIDATION) Validation Error: [ VUID-VkShaderModuleCreateInfo-pCode-08737 ] | MessageID = 0xa5625282 | vkCreateShaderModule(): pCreateInfo->pCode (spirv-val produced an error):
Invalid SPIR-V magic number.
The Vulkan spec states: If pCode is a pointer to SPIR-V code, pCode must adhere to the validation rules described by the Validation Rules within a Module section of the SPIR-V Environment appendix (https://docs.vulkan.org/spec/latest/chapters/shaders.html#VUID-VkShaderModuleCreateInfo-pCode-08737)
/usr/include/c++/14.2.1/bits/shared_ptr_base.h:1350: std::__shared_ptr_access<_Tp, _Lp, <anonymous>, <anonymous> >::element_type& std::__shared_ptr_access<_Tp, _Lp, <anonymous>, <anonymous> >::operator*() const [with _Tp = spirv::Module; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic; bool <anonymous> = false; bool <anonymous> = false; element_type = spirv::Module]: Assertion '_M_get() != nullptr' failed.
Abandon (core dumped)
```