### PR TITLE
Fix wrong method reference in push constants chapter

### DIFF
--- a/tutorial/book/src/dynamic/push_constants.md
+++ b/tutorial/book/src/dynamic/push_constants.md
@@ -62,7 +62,7 @@ struct UniformBufferObject {
 }
 ```
 
-Also remove `model` from the `App::update_command_buffers` method.
+Also remove `model` from the `App::update_uniform_buffer` method.
 
 ```rust,noplaypen
 let view = Mat4::look_at_rh(


### PR DESCRIPTION
First and foremost, great job with the tutorial; I'm enjoying it.

In the push constants chapter there is a wrong method reference 'App::update_command_buffers' as this method gets first introduced in the next chapter, 'recycling_commands'.
It should be ' App::update_uniform_buffer' as in here: [push_constants.md#L14](https://github.com/KyleMayes/vulkanalia/blob/86ddf880a2a4a5d58e4ce40535cba6cde387ab26/tutorial/book/src/dynamic/push_constants.md?plain=1#L14) 